### PR TITLE
Allow a manual error to be passed in to a custom error.

### DIFF
--- a/simple-schema-context.js
+++ b/simple-schema-context.js
@@ -188,7 +188,7 @@ SimpleSchemaValidationContext.prototype.keyErrorMessage = function simpleSchemaV
     return "";
   }
   
-  return self._simpleSchema.messageForError(errorObj.type, errorObj.name, null, errorObj.value);
+  return errorObj.message || self._simpleSchema.messageForError(errorObj.type, errorObj.name, null, errorObj.value);
 };
 
 SimpleSchemaValidationContext.prototype.getErrorObject = function simpleSchemaValidationContextGetErrorObject() {


### PR DESCRIPTION
The allows you to add on-the-fly error messages, like the error message of an API that you don't have control over (but you know which field it corresponds to).

Eg:

```
Meteor.call('something', email, function(error) {
  if (error) {
    errors.addInvalidKeys([{name: 'email', value: email, message: error.reason}]);
  }
});
```

At the moment we do this with a `custom` error type, which formats like `"[value]"`, but this is an ugly hack.
