### PR TITLE
Passing context to optional function

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ validation error if it is missing the `name` property. For example, when there
 are two objects in the friends array and both are missing the `name` property,
 there will be a validation error for both "friends.0.name" and "friends.1.name".
 
+`optional` can be a function. It's context (this) is same as in `custom` validator.
+
 ### min/max
 
 * If `type` is `Number` or `[Number]`, these rules define the minimum or
@@ -890,8 +892,20 @@ Take a look at their documentation.
 
 ### Make a field conditionally required
 
-If you have a field that should be required only in certain circumstances, first make the field
-optional, and then use a custom function similar to this:
+If you have a field that should be required only in certain circumstances you can specify optional function:
+
+```js
+{
+  field: {
+    type: String,
+    optional: function() {
+      return this.field('saleType').value == 1;
+    }
+  }
+}
+```
+
+Or you can, first make the field optional, and then use a custom function similar to this:
 
 ```js
 {
@@ -920,9 +934,6 @@ optional, and then use a custom function similar to this:
 ```
 
 Where `customCondition` is whatever should trigger it being required.
-
-Note: In the future we could make this a bit simpler by allowing `optional` to be a function that returns
-true or false. Pull request welcome.
 
 ### Validate one key against another
 

--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -4097,6 +4097,20 @@ Tinytest.add("SimpleSchema - Autoconvert Dates", function (test) {
   test.length(sc.invalidKeys(), 0);
 });
 
+Tinytest.add("SimpleSchema - optional function dependant on other fields", function (test) {
+  // With $set
+  var schema = new SimpleSchema({
+    a: {type: String},
+    b: {type: String, optional: function() { return this.field('a').value === 'Dont need b' }}
+  });
+
+  var c = schema.namedContext();
+
+  test.isTrue(c.validate({a: 'Dont need b'}));
+  test.isFalse(c.validate({a: 'I need b'}));
+  test.isTrue(c.validate({a: 'I need b', b: 'I am here'}));
+});
+
 /*
  * END TESTS
  */

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -835,11 +835,14 @@ SimpleSchema.prototype.getDefinition = function(key, propList, functionContext) 
 
   // For any options that support specifying a function,
   // evaluate the functions.
-  _.each(['min', 'max', 'minCount', 'maxCount', 'allowedValues', 'optional', 'label'], function (prop) {
+  _.each(['min', 'max', 'minCount', 'maxCount', 'allowedValues', 'label'], function (prop) {
     if (_.isFunction(defs[prop])) {
       defs[prop] = defs[prop].call(functionContext || {});
     }
   });
+  if (functionContext && _.isFunction(defs['optional'])) {
+    defs['optional'] = defs['optional'].call(functionContext || {});
+  }
 
   // Inflect label if not defined
   defs.label = defs.label || inflectedLabel(key);
@@ -960,7 +963,7 @@ SimpleSchema.prototype.messages = function(messages) {
 // def and value arguments to fill in placeholders in the error messages.
 SimpleSchema.prototype.messageForError = function(type, key, def, value) {
   var self = this;
-
+  
   // We proceed even if we can't get a definition because it might be a keyNotInSchema error
   def = def || self.getDefinition(key, ['regEx', 'label', 'minCount', 'maxCount', 'min', 'max', 'type']) || {};
 


### PR DESCRIPTION
if `optional` schema rule is function it gets context passed in. This way we can access other fields value with `this.field` or `this.siblingField` (same as we can in custom validators).
@aldeed could you review this?
