### PR TITLE
Options passed to validator() should be passed on to validate()

### DIFF
--- a/simple-schema.js
+++ b/simple-schema.js
@@ -1179,6 +1179,6 @@ SimpleSchema.prototype.validator = function (options) {
   options = options || {};
   return function (obj) {
     if (options.clean === true) self.clean(obj, options);
-    self.validate(obj);
+    self.validate(obj, options);
   };
 };


### PR DESCRIPTION
At the moment you can call:
`Schemas.CustomerCompaniesSchema.validate(customerModifier, {modifier: true});`
and that will correctly evaluate an object that includes a mongo modifier (`$set`).

However, if you say 
`validate: Schemas.CustomerCompaniesSchema.validator({modifier: true})`
that will not work as the options parameter is only used to check for the need to `clean`, but is then thrown away in `SimpleSchema.prototype.validator` rather than being passed on to `SimpleSchema.prototype.validate`.

I think that's a bug?  It certainly makes it harder to wire autoform up to a validated-method.
