### PR TITLE
Fixes a case that a combined schema is not getting base schema values

### DIFF
--- a/simple-schema-tests.js
+++ b/simple-schema-tests.js
@@ -3493,7 +3493,10 @@ Tinytest.add("SimpleSchema - Mixed Schema Merge With Base Extend and Override", 
     },
     b: {
       type: [String]
-    }
+    },
+    c: {
+      type: [Object]
+    },
   });
 
   var s2 = new SimpleSchema([s1, {
@@ -3503,10 +3506,13 @@ Tinytest.add("SimpleSchema - Mixed Schema Merge With Base Extend and Override", 
       b: {
         label: "Bacon"
       },
-      c: {
+      'c.$.1': {
         type: String
       },
       d: {
+        type: String
+      },
+      e: {
         type: String
       }
     }]);
@@ -3525,9 +3531,19 @@ Tinytest.add("SimpleSchema - Mixed Schema Merge With Base Extend and Override", 
       label: "Bacon"
     },
     c: {
+      type: Array
+    },
+    'c.$': {
+      type: Object,
+      optional: true
+    },
+    'c.$.1': {
       type: String
     },
     d: {
+      type: String
+    },
+    e: {
       type: String
     }
   }, "schema was not merged correctly");
@@ -3535,7 +3551,7 @@ Tinytest.add("SimpleSchema - Mixed Schema Merge With Base Extend and Override", 
   // test validation
   var ctx = s2.namedContext();
   ctx.validate({a: "Wrong"});
-  test.length(ctx.invalidKeys(), 4);
+  test.length(ctx.invalidKeys(), 5);
 
 });
 

--- a/simple-schema.js
+++ b/simple-schema.js
@@ -215,7 +215,7 @@ var mergeSchemas = function(schemas) {
     if (Match.test(schema, SimpleSchema)) {
       schema = schema._schema;
     } else {
-      schema = addImplicitKeys(expandSchema(schema));
+      schema = expandSchema(schema);
     }
 
     // Loop through and extend each individual field
@@ -227,6 +227,9 @@ var mergeSchemas = function(schemas) {
     });
 
   });
+
+  // Adds implied keys on having all schemas merged
+  mergedSchema = addImplicitKeys(mergedSchema);
 
   // If we merged some schemas, do this again to make sure
   // extended definitions are pushed into array item field


### PR DESCRIPTION
I run into an issue which I reported https://github.com/aldeed/meteor-simple-schema/issues/600. I prepared a test case to reproduce the issue and I confirmed that is not working as expected. Basically, when you define a base schema and it has defined an array, and then your specialized schema defines a inner key for such array, the base schema definition for the array is overridden.

My fix was to run `addImplicitKeys` when all schemas (base and specialized) has been merged, instead of do it for each schema, so it does not need to override the base definitions for such case.
